### PR TITLE
Basic Shift Methods

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -91,4 +91,13 @@ class Enigma
       return false
     end
   end
+
+  def generate_shifts_hash(keys, offsets)
+    final_shifts = {
+      a_shift: keys[:a_key] + offsets[:a_offset],
+      b_shift: keys[:b_key] + offsets[:b_offset],
+      c_shift: keys[:c_key] + offsets[:c_offset],
+      d_shift: keys[:d_key] + offsets[:d_offset]
+    }
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -102,13 +102,13 @@ class Enigma
     }
   end
 
-  def rotate_to_change_char(shift, input_char)
-    output_char = input_char
+  def get_new_char_by_shift(shift, input_char)
+    new_char = input_char
     if @character_list.include?(input_char)
       index_value = @character_list.index(input_char)
       rotated_char_list = @character_list.rotate(shift)
-      output_char = rotated_char_list[index_value]
+      new_char = rotated_char_list[index_value]
     end
-    output_char
+    new_char
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,9 +1,10 @@
 require 'date'
 
 class Enigma
-  attr_reader :message
+  attr_reader :message, :character_list
   def initialize
     @message = ''
+    @character_list = ("a".."z").to_a << " "
   end
 
   def parse_message(filename)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -101,4 +101,14 @@ class Enigma
       d_shift: keys[:d_key] + offsets[:d_offset]
     }
   end
+
+  def rotate_to_change_char(shift, input_char)
+    output_char = input_char
+    if @character_list.include?(input_char)
+      index_value = @character_list.index(input_char)
+      rotated_char_list = @character_list.rotate(shift)
+      output_char = rotated_char_list[index_value]
+    end
+    output_char
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -9,7 +9,7 @@ class Enigma
 
   def parse_message(filename)
     file = File.new(filename)
-    @message = file.read
+    @message = file.read.downcase
   end
 
   def generate_random_key_string

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -143,4 +143,32 @@ RSpec.describe Enigma do
       expect(@enigma.generate_shifts_hash(keys, offsets)).to eq shifts
     end
   end
+
+  describe '#rotate_to_change_char' do
+    it 'can rotate the character list instance variable to change a message character' do
+      shift = 3
+      input_char = 'h'
+      output = 'k'
+      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      shift = 27
+      input_char = 'e'
+      output = 'e'
+      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      shift = 73
+      input_char = 'l'
+      output = 'd'
+      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+    end
+
+    it 'does not change a character that does not appear in the character list' do
+      shift = 3
+      input_char = '!'
+      output = '!'
+      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      shift = 42
+      input_char = '^'
+      output = '^'
+      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+    end
+  end
 end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Enigma do
     it 'has an empty message string' do
       expect(@enigma.message).to eq ''
     end
+
+    it 'has a list of all possible characters to mutate' do
+      expect(@enigma.character_list.count).to eq 27
+    end
   end
 
   describe '#parse_message' do

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -144,31 +144,32 @@ RSpec.describe Enigma do
     end
   end
 
-  describe '#rotate_to_change_char' do
+  describe '#get_new_char_by_shift' do
     it 'can rotate the character list instance variable to change a message character' do
       shift = 3
       input_char = 'h'
       output = 'k'
-      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      expect(@enigma.get_new_char_by_shift(shift,input_char)).to eq output
       shift = 27
       input_char = 'e'
       output = 'e'
-      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      expect(@enigma.get_new_char_by_shift(shift,input_char)).to eq output
       shift = 73
       input_char = 'l'
       output = 'd'
-      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      expect(@enigma.get_new_char_by_shift(shift,input_char)).to eq output
     end
 
     it 'does not change a character that does not appear in the character list' do
       shift = 3
       input_char = '!'
       output = '!'
-      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      expect(@enigma.get_new_char_by_shift(shift,input_char)).to eq output
       shift = 42
       input_char = '^'
       output = '^'
-      expect(@enigma.rotate_to_change_char(shift,input_char)).to eq output
+      expect(@enigma.get_new_char_by_shift(shift,input_char)).to eq output
+      # require 'pry'; binding.pry
     end
   end
 end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -137,24 +137,9 @@ RSpec.describe Enigma do
 
   describe '#generate_shifts_hash' do
     it 'can create a hash of final shifts' do
-      keys = {
-        a_key: 02,
-        b_key: 27,
-        c_key: 71,
-        d_key: 15
-      }
-      offsets = {
-        a_offset: 1,
-        b_offset: 0,
-        c_offset: 2,
-        d_offset: 5
-      }
-      shifts = {
-        a_shift: 3,
-        b_shift: 27,
-        c_shift: 73,
-        d_shift: 20
-      }
+      keys = { a_key: 02, b_key: 27, c_key: 71, d_key: 15 }
+      offsets = { a_offset: 1, b_offset: 0, c_offset: 2, d_offset: 5 }
+      shifts = { a_shift: 3, b_shift: 27, c_shift: 73, d_shift: 20 }
       expect(@enigma.generate_shifts_hash(keys, offsets)).to eq shifts
     end
   end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -130,4 +130,28 @@ RSpec.describe Enigma do
       expect(@enigma.is_valid_date?(array)).to eq false
     end
   end
+
+  describe '#generate_shifts_hash' do
+    it 'can create a hash of final shifts' do
+      keys = {
+        a_key: 02,
+        b_key: 27,
+        c_key: 71,
+        d_key: 15
+      }
+      offsets = {
+        a_offset: 1,
+        b_offset: 0,
+        c_offset: 2,
+        d_offset: 5
+      }
+      shifts = {
+        a_shift: 3,
+        b_shift: 27,
+        c_shift: 73,
+        d_shift: 20
+      }
+      expect(@enigma.generate_shifts_hash(keys, offsets)).to eq shifts
+    end
+  end
 end


### PR DESCRIPTION
Adds basic methods for shifting (by utilizing keys and offsets) to the Enigma class. Will parse methods out to necessary classes at a later date.